### PR TITLE
adds warning(cause, ...) overloads to akka typed's logger

### DIFF
--- a/akka-actor-typed/src/main/scala/akka/actor/typed/Logger.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/Logger.scala
@@ -9,7 +9,7 @@ import akka.annotation.{ DoNotInherit, InternalApi }
  * A log marker is an additional metadata tag supported by some logging backends to identify "special" log events.
  * In the Akka internal actors for example the "SECURITY" marker is used for warnings related to security.
  *
- * Not for user extension
+ * Not for user extension, create instances using factory methods
  */
 @DoNotInherit
 sealed trait LogMarker {
@@ -57,10 +57,9 @@ object LogMarker {
  * Provided rather than a specific logging library logging API to not enforce a specific logging library on users but
  * still providing a convenient, performant, asynchronous and testable logging solution. Additionally it allows unified
  * logging for both user implemented actors and built in Akka actors where the actual logging backend can be selected
- * by the user.
+ * by the user. This logging facade is also used by Akka internally, without having to depend on specific logging frameworks.
  *
- * The [[Logger]] of an actor is tied to the actor path and should not be shared with other threads outside of
- * the actor.
+ * The [[Logger]] of an actor is tied to the actor path and should not be shared with other threads outside of the actor.
  *
  * Not for user extension
  */
@@ -280,8 +279,6 @@ abstract class Logger private[akka] () {
    */
   def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit
 
-  /* FIXME these would be nice but cannot see how to pull it off while keeping binary comp in the old logging infra
-  // exception warning logging
   /**
    * Log message at warning level.
    */
@@ -292,25 +289,24 @@ abstract class Logger private[akka] () {
    * If `arg1` is an `Array` it will be expanded into replacement arguments, which is useful when
    * there are more than four arguments.
    *
-   * @see [[ActorLogger]]
+   * @see [[Logger]]
    */
   def warning(cause: Throwable, template: String, arg1: Any): Unit
   /**
    * Message template with 2 replacement arguments.
-   * @see [[ActorLogger]]
+   * @see [[Logger]]
    */
   def warning(cause: Throwable, template: String, arg1: Any, arg2: Any): Unit
   /**
    * Message template with 3 replacement arguments.
-   * @see [[ActorLogger]]
+   * @see [[Logger]]
    */
   def warning(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any): Unit
   /**
    * Message template with 4 replacement arguments. For more parameters see the single replacement version of this method.
-   * @see [[ActorLogger]]
+   * @see [[Logger]]
    */
   def warning(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit
-  */
 
   // marker warning logging
   /**
@@ -353,49 +349,48 @@ abstract class Logger private[akka] () {
    */
   def warning(marker: LogMarker, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit
 
-  /* FIXME these would be nice but cannot see how to pull it off while keeping binary comp in the old logging infra
   /**
-  * Log message at warning level.
-  *
-  * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
-  */
+   * Log message at warning level.
+   *
+   * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
+   * @see [[Logger]]
+   */
   def warning(marker: LogMarker, cause: Throwable, message: String): Unit
   /**
-  * Message template with 1 replacement argument.
-  *
-  * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
-  *
-  * If `arg1` is an `Array` it will be expanded into replacement arguments, which is useful when
-  * there are more than four arguments.
-  *
-  * @see [[ActorLogger]]
-  */
+   * Message template with 1 replacement argument.
+   *
+   * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
+   *
+   * If `arg1` is an `Array` it will be expanded into replacement arguments, which is useful when
+   * there are more than four arguments.
+   *
+   * @see [[Logger]]
+   */
   def warning(marker: LogMarker, cause: Throwable, template: String, arg1: Any): Unit
   /**
-  * Message template with 2 replacement arguments.
-  *
-  * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
-  *
-  * @see [[ActorLogger]]
-  */
+   * Message template with 2 replacement arguments.
+   *
+   * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
+   *
+   * @see [[Logger]]
+   */
   def warning(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any): Unit
   /**
-  * Message template with 3 replacement arguments.
-  *
-  * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
-  *
-  * @see [[ActorLogger]]
-  */
+   * Message template with 3 replacement arguments.
+   *
+   * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
+   *
+   * @see [[Logger]]
+   */
   def warning(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any): Unit
   /**
-  * Message template with 4 replacement arguments. For more parameters see the single replacement version of this method.
-  *
-  * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
-  *
-  * @see [[ActorLogger]]
-  */
+   * Message template with 4 replacement arguments. For more parameters see the single replacement version of this method.
+   *
+   * The marker argument can be picked up by various logging frameworks such as slf4j to mark this log statement as "special".
+   *
+   * @see [[Logger]]
+   */
   def warning(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit
-  */
 
   // message only info logging
 

--- a/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/LoggerAdapterImpl.scala
+++ b/akka-actor-typed/src/main/scala/akka/actor/typed/internal/adapter/LoggerAdapterImpl.scala
@@ -103,43 +103,83 @@ private[akka] class LoggerAdapterImpl(bus: LoggingBus, logClass: Class[_], logSo
   }
 
   override def warning(message: String): Unit = {
-    if (isWarningEnabled) notifyWarning(message, OptionVal.None)
+    if (isWarningEnabled) notifyWarning(message, OptionVal.None, OptionVal.None)
   }
 
   override def warning(template: String, arg1: Any): Unit = {
-    if (isWarningEnabled) notifyWarning(format(template, arg1), OptionVal.None)
+    if (isWarningEnabled) notifyWarning(format(template, arg1), OptionVal.None, OptionVal.None)
   }
 
   override def warning(template: String, arg1: Any, arg2: Any): Unit = {
-    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2), OptionVal.None)
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2), OptionVal.None, OptionVal.None)
   }
 
   override def warning(template: String, arg1: Any, arg2: Any, arg3: Any): Unit = {
-    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3), OptionVal.None)
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3), OptionVal.None, OptionVal.None)
   }
 
   override def warning(template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = {
-    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4), OptionVal.None)
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4), OptionVal.None, OptionVal.None)
+  }
+
+  override def warning(cause: Throwable, message: String): Unit = {
+    if (isWarningEnabled) notifyWarning(message, OptionVal.None, OptionVal.Some(cause))
+  }
+
+  override def warning(cause: Throwable, template: String, arg1: Any): Unit = {
+    if (isWarningEnabled) notifyWarning(format(template, arg1), OptionVal.None, OptionVal.Some(cause))
+  }
+
+  override def warning(cause: Throwable, template: String, arg1: Any, arg2: Any): Unit = {
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2), OptionVal.None, OptionVal.Some(cause))
+  }
+
+  override def warning(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any): Unit = {
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3), OptionVal.None, OptionVal.Some(cause))
+  }
+
+  override def warning(cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = {
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4), OptionVal.None, OptionVal.Some(cause))
+  }
+
+  override def warning(marker: LogMarker, cause: Throwable, template: String, arg1: Any): Unit = {
+    if (isWarningEnabled) notifyWarning(format(template, arg1), OptionVal.Some(marker), OptionVal.Some(cause))
+  }
+
+  override def warning(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any): Unit = {
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2), OptionVal.Some(marker), OptionVal.Some(cause))
+  }
+
+  override def warning(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any): Unit = {
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3), OptionVal.Some(marker), OptionVal.Some(cause))
+  }
+
+  override def warning(marker: LogMarker, cause: Throwable, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = {
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4), OptionVal.Some(marker), OptionVal.Some(cause))
+  }
+
+  override def warning(marker: LogMarker, cause: Throwable, message: String): Unit = {
+    if (isWarningEnabled) notifyWarning(message, OptionVal.Some(marker), OptionVal.Some(cause))
   }
 
   override def warning(marker: LogMarker, message: String): Unit = {
-    if (isWarningEnabled) notifyWarning(message, OptionVal.Some(marker))
+    if (isWarningEnabled) notifyWarning(message, OptionVal.Some(marker), OptionVal.None)
   }
 
   override def warning(marker: LogMarker, template: String, arg1: Any): Unit = {
-    if (isWarningEnabled) notifyWarning(format(template, arg1), OptionVal.Some(marker))
+    if (isWarningEnabled) notifyWarning(format(template, arg1), OptionVal.Some(marker), OptionVal.None)
   }
 
   override def warning(marker: LogMarker, template: String, arg1: Any, arg2: Any): Unit = {
-    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2), OptionVal.Some(marker))
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2), OptionVal.Some(marker), OptionVal.None)
   }
 
   override def warning(marker: LogMarker, template: String, arg1: Any, arg2: Any, arg3: Any): Unit = {
-    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3), OptionVal.Some(marker))
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3), OptionVal.Some(marker), OptionVal.None)
   }
 
   override def warning(marker: LogMarker, template: String, arg1: Any, arg2: Any, arg3: Any, arg4: Any): Unit = {
-    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4), OptionVal.Some(marker))
+    if (isWarningEnabled) notifyWarning(format(template, arg1, arg2, arg3, arg4), OptionVal.Some(marker), OptionVal.None)
   }
 
   override def info(message: String): Unit = {
@@ -238,11 +278,18 @@ private[akka] class LoggerAdapterImpl(bus: LoggingBus, logClass: Class[_], logSo
     bus.publish(error)
   }
 
-  protected def notifyWarning(message: String, marker: OptionVal[LogMarker]): Unit = {
-    val warning = marker match {
-      case OptionVal.Some(m) ⇒ Warning(logSource, logClass, message, mdc, m.asInstanceOf[UntypedLM])
-      case OptionVal.None    ⇒ Warning(logSource, logClass, message, mdc)
-    }
+  @Deprecated
+  @deprecated("Use the 3 argument version instead", since = "2.5.10")
+  protected def notifyWarning(message: String, marker: OptionVal[LogMarker]): Unit =
+    notifyWarning(message, marker, OptionVal.None)
+
+  protected def notifyWarning(message: String, marker: OptionVal[LogMarker], cause: OptionVal[Throwable]): Unit = {
+    val warning =
+      if (cause.isDefined) Warning(cause.get, logSource, logClass, message, mdc, marker.orNull.asInstanceOf[UntypedLM])
+      else marker match {
+        case OptionVal.Some(m) ⇒ Warning(logSource, logClass, message, mdc, m.asInstanceOf[UntypedLM])
+        case OptionVal.None    ⇒ Warning(logSource, logClass, message, mdc)
+      }
     bus.publish(warning)
   }
 

--- a/akka-actor/src/main/scala/akka/event/Logging.scala
+++ b/akka-actor/src/main/scala/akka/event/Logging.scala
@@ -739,17 +739,21 @@ object Logging {
 
   }
 
+  trait LogEventWithCause {
+    def cause: Throwable
+  }
+
   /**
    * For ERROR Logging
    */
-  case class Error(cause: Throwable, logSource: String, logClass: Class[_], message: Any = "") extends LogEvent {
+  case class Error(override val cause: Throwable, logSource: String, logClass: Class[_], message: Any = "") extends LogEvent with LogEventWithCause {
     def this(logSource: String, logClass: Class[_], message: Any) = this(Error.NoCause, logSource, logClass, message)
     override def level = ErrorLevel
   }
-  class Error2(cause: Throwable, logSource: String, logClass: Class[_], message: Any = "", override val mdc: MDC) extends Error(cause, logSource, logClass, message) {
+  class Error2(override val cause: Throwable, logSource: String, logClass: Class[_], message: Any = "", override val mdc: MDC) extends Error(cause, logSource, logClass, message) {
     def this(logSource: String, logClass: Class[_], message: Any, mdc: MDC) = this(Error.NoCause, logSource, logClass, message, mdc)
   }
-  class Error3(cause: Throwable, logSource: String, logClass: Class[_], message: Any, override val mdc: MDC, override val marker: LogMarker)
+  class Error3(override val cause: Throwable, logSource: String, logClass: Class[_], message: Any, override val mdc: MDC, override val marker: LogMarker)
     extends Error2(cause, logSource, logClass, message, mdc) with LogEventWithMarker {
     def this(logSource: String, logClass: Class[_], message: Any, mdc: MDC, marker: LogMarker) = this(Error.NoCause, logSource, logClass, message, mdc, marker)
   }
@@ -784,9 +788,14 @@ object Logging {
   class Warning2(logSource: String, logClass: Class[_], message: Any, override val mdc: MDC) extends Warning(logSource, logClass, message)
   class Warning3(logSource: String, logClass: Class[_], message: Any, override val mdc: MDC, override val marker: LogMarker)
     extends Warning2(logSource, logClass, message, mdc) with LogEventWithMarker
+  class Warning4(logSource: String, logClass: Class[_], message: Any, override val mdc: MDC, override val marker: LogMarker, override val cause: Throwable)
+    extends Warning2(logSource, logClass, message, mdc) with LogEventWithMarker with LogEventWithCause
   object Warning {
     def apply(logSource: String, logClass: Class[_], message: Any, mdc: MDC) = new Warning2(logSource, logClass, message, mdc)
     def apply(logSource: String, logClass: Class[_], message: Any, mdc: MDC, marker: LogMarker) = new Warning3(logSource, logClass, message, mdc, marker)
+
+    def apply(cause: Throwable, logSource: String, logClass: Class[_], message: Any, mdc: MDC) = new Warning4(logSource, logClass, message, mdc, null, cause)
+    def apply(cause: Throwable, logSource: String, logClass: Class[_], message: Any, mdc: MDC, marker: LogMarker) = new Warning4(logSource, logClass, message, mdc, marker, cause)
   }
 
   /**

--- a/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
+++ b/akka-slf4j/src/main/scala/akka/event/slf4j/Slf4jLogger.scala
@@ -72,7 +72,10 @@ class Slf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Logg
 
     case event @ Warning(logSource, logClass, message) ⇒
       withMdc(logSource, event) {
-        Logger(logClass, logSource).warn(markerIfPresent(event), "{}", message.asInstanceOf[AnyRef])
+        event match {
+          case e: LogEventWithCause ⇒ Logger(logClass, logSource).warn(markerIfPresent(event), if (message != null) message.toString else null, e.cause)
+          case _                    ⇒ Logger(logClass, logSource).warn(markerIfPresent(event), if (message != null) message.toString else null)
+        }
       }
 
     case event @ Info(logSource, logClass, message) ⇒

--- a/akka-testkit-typed/src/main/scala/akka/testkit/typed/StubbedActorContext.scala
+++ b/akka-testkit-typed/src/main/scala/akka/testkit/typed/StubbedActorContext.scala
@@ -54,7 +54,7 @@ final case class CapturedLogEvent(logLevel: LogLevel, message: String, cause: Op
   override protected def notifyError(message: String, cause: OptionVal[Throwable], marker: OptionVal[LogMarker]): Unit =
     logBuffer = CapturedLogEvent(Logging.ErrorLevel, message, cause, marker) :: logBuffer
 
-  override protected def notifyWarning(message: String, marker: OptionVal[LogMarker]): Unit =
+  override protected def notifyWarning(message: String, marker: OptionVal[LogMarker], cause: OptionVal[Throwable]): Unit =
     logBuffer = CapturedLogEvent(Logging.WarningLevel, message, OptionVal.None, marker) :: logBuffer
 
   override protected def notifyInfo(message: String, marker: OptionVal[LogMarker]): Unit =


### PR DESCRIPTION
Adds `.warning(cause, ...` and `.warning(marker, cause, ...)` overloads in a bin compat fashion.

This PR is into the `Logging for typed` PR #24386